### PR TITLE
fix/binbin1760/解决自定义刷新造成的流程页面数据异常BUG

### DIFF
--- a/src/views/system-setting/base.ts
+++ b/src/views/system-setting/base.ts
@@ -12,8 +12,6 @@
  *
  */
 
-import LogicFlow from '@logicflow/core'
-
 export interface BaseNodeType {
   name: string
   des: string

--- a/src/views/system-setting/work-flow/components/flow-set/index.vue
+++ b/src/views/system-setting/work-flow/components/flow-set/index.vue
@@ -377,7 +377,10 @@
   }
 
   async function updateNodePosition(data: EidtRelationXY) {
-    await updateFlowNodeRelationXy(data)
+    const res = await updateFlowNodeRelationXy(data)
+    if (res.code) {
+      refreshRender()
+    }
   }
   onMounted(() => {
     const container = document.querySelector('#flow-contain')
@@ -399,7 +402,7 @@
         keyboard: {
           enabled: true
         },
-        isSilentMode: true,
+        isSilentMode: selectFlow.value ? false : true,
         nodeTextEdit: false
       })
       if (flowInstance.value) {


### PR DESCRIPTION
状态管理器是单例模式，自定义刷新页面组件只是重新加载页面组件，不会更新状态管理器中的数据。